### PR TITLE
Implement, test and document the estimateReadingTime fn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm i -S web-utils-kit
 - `src/index.ts` is the flat consumer-facing package API. Consumers import supported functions and types directly from `web-utils-kit`.
 - `src/validations/` owns validation functions and exposes them through a thin, explicit module entry file.
 - `src/transformers/` groups date, JSON, number, and string transformations behind a thin, explicit module entry file.
-- `src/utils/` groups async, collection, extraction, filtering, generation, Markdown, pagination, and sorting utilities behind a thin, explicit module entry file.
+- `src/utils/` groups async, collection, extraction, filtering, generation, Markdown, pagination, reading, and sorting utilities behind a thin, explicit module entry file.
 - `src/test-utils/` provides code-aware assertions for synchronous throws and promise rejections.
 - `src/shared/` contains contracts and error definitions shared by the package modules.
 
@@ -1117,6 +1117,24 @@ await res.json();
     'croatoan'
   );
   // [{ a: { x: 'Hello', y: ['yak', 123], p: { a: { b: 'croatoan' } }, z: { foo: 'bar' } } }]
+  ```
+  <br/>
+</details>
+
+<details>
+  <summary><code>estimateReadingTime</code></summary>
+  <br/>
+
+  Estimates how long text takes to read at an average speed of 200 words per minute and returns the duration in milliseconds. Words are separated by whitespace. Non-string and empty inputs return `0`.
+
+  ```typescript
+  import { estimateReadingTime, prettifyTime } from 'web-utils-kit';
+
+  const article = 'word '.repeat(200);
+
+  estimateReadingTime(article); // 60_000
+  prettifyTime(estimateReadingTime(article)); // '1m'
+  estimateReadingTime('   '); // 0
   ```
   <br/>
 </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-utils-kit",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-utils-kit",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "error-message-utils": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-utils-kit",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "The web-utils-kit package provides a collection of well-tested and thoroughly documented utility functions for various web development needs. Each function adheres to a strict coding style and best practices to ensure consistency and maintainability.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.test-unit.ts
+++ b/src/index.test-unit.ts
@@ -3,9 +3,11 @@ import { describe, expect, test } from 'vitest';
 
 import {
   applyDefaults,
+  estimateReadingTime,
   expectToRejectCode,
   expectToThrowCode,
   MAX_EMAIL_LENGTH,
+  prettifyTime,
   splitArrayIntoBatches,
 } from './index.js';
 
@@ -25,5 +27,9 @@ describe('public API', () => {
 
   test('exports validation constants from the package entry point', () => {
     expect(MAX_EMAIL_LENGTH).toBe(320);
+  });
+
+  test('exports composable reading-time utilities from the package entry point', () => {
+    expect(prettifyTime(estimateReadingTime('word '.repeat(200)))).toBe('1m');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export {
   extractEmailUsername,
   getInitials,
   getNextPageParam,
+  estimateReadingTime,
   extractFirstMarkdownHeadingName,
   extractSubstitutionPlaceholderNames,
 } from './utils/index.js';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -43,6 +43,9 @@ export {
 // pagination utilities
 export { getNextPageParam } from './pagination.js';
 
+// reading utilities
+export { estimateReadingTime } from './reading.js';
+
 // sorting utilities
 export {
   sortPrimitives,

--- a/src/utils/reading.test-unit.ts
+++ b/src/utils/reading.test-unit.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { describe, expect, test } from 'vitest';
+
+import { estimateReadingTime } from './reading.js';
+
+describe('estimateReadingTime', () => {
+  test.each(<Array<[unknown, number]>>[
+    [undefined, 0],
+    [null, 0],
+    [false, 0],
+    [123, 0],
+    [[], 0],
+    [{}, 0],
+    ['', 0],
+    ['   \t\n  ', 0],
+    ['word', 300],
+    ['two words', 600],
+    ['  spaces   between\twords\nand lines  ', 1_500],
+    ['words\u00a0separated\u00a0by non-breaking spaces', 1_500],
+    ['word '.repeat(200), 60_000],
+    ['word '.repeat(201), 60_300],
+  ])('estimateReadingTime(%o) -> %d', (text, expected) => {
+    expect(estimateReadingTime(text)).toBe(expected);
+  });
+});

--- a/src/utils/reading.ts
+++ b/src/utils/reading.ts
@@ -1,0 +1,24 @@
+// reading-time calculation values based on an average adult reading speed
+const AVERAGE_READING_WORDS_PER_MINUTE = 200;
+const MILLISECONDS_PER_MINUTE = 60_000;
+
+/**
+ * Estimates how long text takes to read at 200 words per minute.
+ * @param text The text whose reading time will be estimated.
+ * @returns The estimated reading time in milliseconds, or 0 for non-string or empty input.
+ */
+export const estimateReadingTime = (text: unknown): number => {
+  if (typeof text !== 'string') {
+    return 0;
+  }
+
+  const normalizedText = text.trim();
+
+  if (normalizedText.length === 0) {
+    return 0;
+  }
+
+  const wordCount = normalizedText.split(/\s+/).length;
+
+  return Math.ceil((wordCount * MILLISECONDS_PER_MINUTE) / AVERAGE_READING_WORDS_PER_MINUTE);
+};


### PR DESCRIPTION
Expose a 200-word-per-minute estimator that returns milliseconds and composes with prettifyTime. Document and verify the public API, update package metadata for 1.3.2, and keep local AGENTS.md guidance untracked.